### PR TITLE
Use public instead of internal

### DIFF
--- a/Notes.md
+++ b/Notes.md
@@ -16,7 +16,8 @@ Backlog
    - finish unit tests in C#
    - real configuration UI
    - mark callbacks in UT as .Verifiable() and call Mock.Verify() at the end
-   - give up on using internal, switch to public (it just creates problems)
+   - installer takes forever to kill running ShadowKVM.exe
+      - maybe it's sending WM_CLOSE to wrong windows?
 
 - nice to have
    - parallelize monitorInputService.TryLoadMonitorInputs in ConfigGenerator

--- a/ShadowKVM.Tests/Config/ConfigGenerator_Generate.cs
+++ b/ShadowKVM.Tests/Config/ConfigGenerator_Generate.cs
@@ -4,9 +4,9 @@ namespace ShadowKVM.Tests;
 
 public class ConfigGenerator_GenerateTest
 {
-    internal Mock<IMonitorService> _monitorServiceMock = new();
-    internal Mock<IMonitorInputService> _monitorInputServiceMock = new();
-    internal Mock<IProgress<ConfigGeneratorStatus>> _progressMock = new();
+    public Mock<IMonitorService> _monitorServiceMock = new();
+    public Mock<IMonitorInputService> _monitorInputServiceMock = new();
+    public Mock<IProgress<ConfigGeneratorStatus>> _progressMock = new();
 
     [Fact]
     public void Generate_LoadMonitorsThrows()

--- a/ShadowKVM.Tests/Config/ConfigGenerator_Template.cs
+++ b/ShadowKVM.Tests/Config/ConfigGenerator_Template.cs
@@ -21,8 +21,8 @@ namespace ShadowKVM.Tests;
 
 public class ConfigGenerator_TemplateTest
 {
-    internal Mock<IMonitorService> _monitorServiceMock = new();
-    internal Mock<IMonitorInputService> _monitorInputServiceMock = new();
+    public Mock<IMonitorService> _monitorServiceMock = new();
+    public Mock<IMonitorInputService> _monitorInputServiceMock = new();
 
     static SafePhysicalMonitorHandle NH = SafePhysicalMonitorHandle.Null; // short name for null handle
 

--- a/ShadowKVM.Tests/Devices/DeviceNotification.cs
+++ b/ShadowKVM.Tests/Devices/DeviceNotification.cs
@@ -8,7 +8,7 @@ namespace ShadowKVM.Tests;
 
 public class DeviceNotificationTest
 {
-    internal Mock<IWindowsAPI> _windowsAPIMock = new();
+    public Mock<IWindowsAPI> _windowsAPIMock = new();
 
     static Guid _testGuid = new("{582a0a58-a22c-431a-bffe-8e381e0522e7}");
 

--- a/ShadowKVM.Tests/Devices/MonitorInputService.cs
+++ b/ShadowKVM.Tests/Devices/MonitorInputService.cs
@@ -9,9 +9,9 @@ namespace ShadowKVM.Tests;
 
 public class MonitorInputServiceTest
 {
-    internal Mock<IWindowsAPI> _windowsAPIMock = new();
-    internal Mock<ICapabilitiesParser> _capabilitiesParser = new();
-    internal Mock<ILogger> _loggerApiMock = new();
+    public Mock<IWindowsAPI> _windowsAPIMock = new();
+    public Mock<ICapabilitiesParser> _capabilitiesParser = new();
+    public Mock<ILogger> _loggerApiMock = new();
 
     SafePhysicalMonitorHandle _handle12345;
 

--- a/ShadowKVM.Tests/Devices/MonitorServiceFixture.cs
+++ b/ShadowKVM.Tests/Devices/MonitorServiceFixture.cs
@@ -9,8 +9,8 @@ namespace ShadowKVM.Tests;
 
 public class MonitorServiceFixture
 {
-    internal Mock<IWindowsAPI> _windowsAPIMock = new();
-    internal Mock<ILogger> _loggerApiMock = new();
+    public Mock<IWindowsAPI> _windowsAPIMock = new();
+    public Mock<ILogger> _loggerApiMock = new();
 
     protected class LoadPhysicalMonitors_Monitor
     {

--- a/ShadowKVM/Config/Config.cs
+++ b/ShadowKVM/Config/Config.cs
@@ -2,7 +2,7 @@ using Serilog.Events;
 
 namespace ShadowKVM;
 
-internal class Config
+public class Config
 {
     public int Version { get; set; }
     public LogEventLevel LogLevel { get; set; } = LogEventLevel.Information;
@@ -14,7 +14,7 @@ internal class Config
     public byte[]? LoadedChecksum { get; set; }
 }
 
-internal class MonitorConfig
+public class MonitorConfig
 {
     public string? Description { get; set; }
     public string? Adapter { get; set; }
@@ -51,7 +51,7 @@ public enum VcpValueEnum : byte
     Hdmi2 = 0x12
 }
 
-internal class ActionConfig
+public class ActionConfig
 {
     public OpenEnumByte<VcpCodeEnum> Code { get; set; } = new OpenEnumByte<VcpCodeEnum>();
     public OpenEnumByte<VcpValueEnum> Value { get; set; } = new OpenEnumByte<VcpValueEnum>();

--- a/ShadowKVM/Config/ConfigException.cs
+++ b/ShadowKVM/Config/ConfigException.cs
@@ -3,7 +3,7 @@ using YamlDotNet.Core;
 
 namespace ShadowKVM;
 
-internal class ConfigException : Exception
+public class ConfigException : Exception
 {
     public ConfigException(string message)
         : base(message)
@@ -16,7 +16,7 @@ internal class ConfigException : Exception
     }
 }
 
-internal class ConfigFileException : ConfigException
+public class ConfigFileException : ConfigException
 {
     public ConfigFileException(string path, YamlException exception)
         : base(string.Empty, exception)

--- a/ShadowKVM/Config/ConfigGenerator.cs
+++ b/ShadowKVM/Config/ConfigGenerator.cs
@@ -12,12 +12,12 @@ public class ConfigGeneratorStatus
     public int Maximum { get; set; }
 }
 
-internal interface IConfigGenerator
+public interface IConfigGenerator
 {
     public string Generate(IProgress<ConfigGeneratorStatus>? progress = null);
 }
 
-internal class ConfigGenerator(IMonitorService monitorService, IMonitorInputService monitorInputService) : IConfigGenerator
+public class ConfigGenerator(IMonitorService monitorService, IMonitorInputService monitorInputService) : IConfigGenerator
 {
     public unsafe string Generate(IProgress<ConfigGeneratorStatus>? progress = null)
     {
@@ -69,7 +69,7 @@ internal class ConfigGenerator(IMonitorService monitorService, IMonitorInputServ
     }
 }
 
-internal class CommonTemplateData
+public class CommonTemplateData
 {
     public string AllCodes => FormatAllEnumValues<VcpCodeEnum>();
     public string AllValues => FormatAllEnumValues<VcpValueEnum>();
@@ -100,13 +100,13 @@ internal class CommonTemplateData
     }
 }
 
-internal class MonitorTemplateData
+public class MonitorTemplateData
 {
     public required Monitor Monitor { get; set; }
     public required MonitorInputsTemplateData Inputs { get; set; }
 }
 
-internal class MonitorInputsTemplateData(MonitorInputs? inputs)
+public class MonitorInputsTemplateData(MonitorInputs? inputs)
 {
     public string CommentUnsupported => inputs != null ? "  " : "# ";
 

--- a/ShadowKVM/Config/ConfigService.cs
+++ b/ShadowKVM/Config/ConfigService.cs
@@ -7,14 +7,14 @@ using YamlDotNet.Serialization.NamingConventions;
 
 namespace ShadowKVM;
 
-internal interface IConfigService
+public interface IConfigService
 {
     public string ConfigPath { get; }
     bool NeedReloadConfig(Config config);
     public Config LoadConfig();
 }
 
-internal class ConfigService : IConfigService
+public class ConfigService : IConfigService
 {
     public ConfigService(string dataDirectory, IFileSystem fileSystem)
     {

--- a/ShadowKVM/Config/OpenEnum.cs
+++ b/ShadowKVM/Config/OpenEnum.cs
@@ -4,7 +4,7 @@ using YamlDotNet.Core.Events;
 
 namespace ShadowKVM;
 
-internal abstract class OpenEnum<TEnum, TRaw>
+public abstract class OpenEnum<TEnum, TRaw>
     where TEnum : struct, Enum
 {
     public OpenEnum()
@@ -53,7 +53,7 @@ internal abstract class OpenEnum<TEnum, TRaw>
     protected abstract TRaw ConvertEnumToRaw(TEnum enumValue);
 }
 
-internal abstract class OpenEnumYamlTypeConverter<TOpenEnum, TEnum, TRaw>(INamingConvention namingConvention) : IYamlTypeConverter
+public abstract class OpenEnumYamlTypeConverter<TOpenEnum, TEnum, TRaw>(INamingConvention namingConvention) : IYamlTypeConverter
     where TOpenEnum : OpenEnum<TEnum, TRaw>, new()
     where TEnum : struct, Enum
 {

--- a/ShadowKVM/Config/OpenEnumByte.cs
+++ b/ShadowKVM/Config/OpenEnumByte.cs
@@ -3,7 +3,7 @@ using YamlDotNet.Serialization;
 
 namespace ShadowKVM;
 
-internal class OpenEnumByte<TEnum> : OpenEnum<TEnum, byte>
+public class OpenEnumByte<TEnum> : OpenEnum<TEnum, byte>
     where TEnum : struct, Enum // TEnum should also use byte as underlying type
 {
     public OpenEnumByte()
@@ -31,7 +31,7 @@ internal class OpenEnumByte<TEnum> : OpenEnum<TEnum, byte>
     }
 }
 
-internal class OpenEnumByteYamlTypeConverter<TEnum>(INamingConvention namingConvention)
+public class OpenEnumByteYamlTypeConverter<TEnum>(INamingConvention namingConvention)
         : OpenEnumYamlTypeConverter<OpenEnumByte<TEnum>, TEnum, byte>(namingConvention)
     where TEnum : struct, Enum
 {

--- a/ShadowKVM/Config/TriggerDevice.cs
+++ b/ShadowKVM/Config/TriggerDevice.cs
@@ -5,7 +5,7 @@ namespace ShadowKVM;
 
 public enum TriggerDeviceType { Keyboard, Mouse }
 
-internal class TriggerDevice : OpenEnum<TriggerDeviceType, Guid>
+public class TriggerDevice : OpenEnum<TriggerDeviceType, Guid>
 {
     public TriggerDevice()
     {
@@ -27,7 +27,7 @@ internal class TriggerDevice : OpenEnum<TriggerDeviceType, Guid>
     }
 }
 
-internal class TriggerDeviceConverter(INamingConvention namingConvention)
+public class TriggerDeviceConverter(INamingConvention namingConvention)
         : OpenEnumYamlTypeConverter<TriggerDevice, TriggerDeviceType, Guid>(namingConvention)
 {
     protected override bool TryConvertStringToRaw(string str, out Guid rawValue)

--- a/ShadowKVM/Devices/BackgroundTask.cs
+++ b/ShadowKVM/Devices/BackgroundTask.cs
@@ -4,7 +4,7 @@ using Windows.Win32;
 
 namespace ShadowKVM;
 
-internal class BackgroundTask(
+public class BackgroundTask(
     Config config,
     IDeviceNotificationService deviceNotificationService,
     IMonitorService monitorService) : IDisposable

--- a/ShadowKVM/Devices/CapabilitiesParser.cs
+++ b/ShadowKVM/Devices/CapabilitiesParser.cs
@@ -8,13 +8,13 @@ using Serilog;
 
 namespace ShadowKVM;
 
-internal interface ICapabilitiesParser
+public interface ICapabilitiesParser
 {
-    internal abstract class Component
+    public abstract class Component
     {
     }
 
-    internal class VcpComponent : Component
+    public class VcpComponent : Component
     {
         public required Dictionary<byte, List<byte>> Codes { get; set; }
     }
@@ -22,7 +22,7 @@ internal interface ICapabilitiesParser
     public VcpComponent? Parse(string input);
 }
 
-internal class CapabilitiesParser(ILogger logger) : ICapabilitiesParser
+public class CapabilitiesParser(ILogger logger) : ICapabilitiesParser
 {
     public ICapabilitiesParser.VcpComponent? Parse(string input)
     {

--- a/ShadowKVM/Devices/DeviceNotification.cs
+++ b/ShadowKVM/Devices/DeviceNotification.cs
@@ -6,12 +6,12 @@ using Windows.Win32.Foundation;
 
 namespace ShadowKVM;
 
-internal interface IDeviceNotificationService
+public interface IDeviceNotificationService
 {
     IDeviceNotification Register(Guid deviceClassGuid);
 }
 
-internal class DeviceNotificationService(IWindowsAPI windowsAPI) : IDeviceNotificationService
+public class DeviceNotificationService(IWindowsAPI windowsAPI) : IDeviceNotificationService
 {
     public IDeviceNotification Register(Guid deviceClassGuid)
     {
@@ -31,7 +31,7 @@ public interface IDeviceNotification : IDisposable
     public ChannelReader<Action> Reader { get; }
 }
 
-internal class DeviceNotification : IDeviceNotification
+public class DeviceNotification : IDeviceNotification
 {
     public DeviceNotification(IWindowsAPI windowsAPI)
     {
@@ -109,5 +109,5 @@ internal class DeviceNotification : IDeviceNotification
 
     IWindowsAPI _windowsAPI;
     Channel<IDeviceNotification.Action> _channel;
-    internal CM_Unregister_NotificationSafeHandle? _notification; // internal for unit tests, don't use
+    public CM_Unregister_NotificationSafeHandle? _notification; // public for unit tests, don't use
 }

--- a/ShadowKVM/Devices/MonitorInputService.cs
+++ b/ShadowKVM/Devices/MonitorInputService.cs
@@ -12,13 +12,13 @@ public class MonitorInputs
     public required byte SelectedInput { get; set; }
 }
 
-internal interface IMonitorInputService
+public interface IMonitorInputService
 {
     public bool TryLoadMonitorInputs(Monitor monitor, [NotNullWhen(true)] out MonitorInputs? monitorInputs);
     public bool TryLoadMonitorInputs(SafePhysicalMonitorHandle physicalMonitorHandle, [NotNullWhen(true)] out MonitorInputs? monitorInputs);
 }
 
-internal class MonitorInputService(IWindowsAPI windowsAPI, ICapabilitiesParser capabilitiesParser, ILogger logger) : IMonitorInputService
+public class MonitorInputService(IWindowsAPI windowsAPI, ICapabilitiesParser capabilitiesParser, ILogger logger) : IMonitorInputService
 {
     public bool TryLoadMonitorInputs(Monitor monitor, [NotNullWhen(true)] out MonitorInputs? monitorInputs)
     {

--- a/ShadowKVM/Devices/MonitorService.cs
+++ b/ShadowKVM/Devices/MonitorService.cs
@@ -8,13 +8,13 @@ using Windows.Win32.Graphics.Gdi;
 
 namespace ShadowKVM;
 
-internal interface IMonitorService
+public interface IMonitorService
 {
     public Monitors LoadMonitors();
 }
 
 // Partial class because of GeneratedRegex
-internal partial class MonitorService(IWindowsAPI windowsAPI, ILogger logger) : IMonitorService
+public partial class MonitorService(IWindowsAPI windowsAPI, ILogger logger) : IMonitorService
 {
     public Monitors LoadMonitors()
     {

--- a/ShadowKVM/Devices/WindowsAPI.cs
+++ b/ShadowKVM/Devices/WindowsAPI.cs
@@ -38,7 +38,7 @@ public interface IWindowsAPI
         PCM_NOTIFY_CALLBACK pCallback, out CM_Unregister_NotificationSafeHandle pNotifyContext);
 }
 
-internal class WindowsAPI : IWindowsAPI
+public class WindowsAPI : IWindowsAPI
 {
     // For MonitorService
     public BOOL GetMonitorInfo(HMONITOR hMonitor, ref MONITORINFOEXW lpmi)

--- a/ShadowKVM/UserInterface/AssemblyInfo.cs
+++ b/ShadowKVM/UserInterface/AssemblyInfo.cs
@@ -3,7 +3,3 @@ using System.Windows;
 
 // Theme specific and generic resource dictionaies
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]
-
-// Allow the test project to access internal classes
-[assembly: InternalsVisibleTo("ShadowKVM.Tests")]
-[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")] // for Moq

--- a/ShadowKVM/UserInterface/Autostart.cs
+++ b/ShadowKVM/UserInterface/Autostart.cs
@@ -3,7 +3,7 @@ using Serilog;
 
 namespace ShadowKVM;
 
-internal static class Autostart
+public static class Autostart
 {
     static string EnabledRegistryKey = @"Software\Microsoft\Windows\CurrentVersion\Run";
     static string EnabledRegistryValue = "Shadow KVM";

--- a/ShadowKVM/UserInterface/Services.cs
+++ b/ShadowKVM/UserInterface/Services.cs
@@ -3,7 +3,7 @@ using Serilog;
 
 namespace ShadowKVM;
 
-internal class Services
+public class Services
 {
     public Services(string dataDirectory)
     {


### PR DESCRIPTION
Using internal is challenging with unit tests, it just creates headaches. This is a standalone application, doesn't have an accessible API, so it makes no practical difference.